### PR TITLE
Add Gnome Shell 45 compatibility.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,18 +1,15 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const Lang = imports.lang;
-const Gio = imports.gi.Gio;
-const GObject = imports.gi.GObject;
-const St = imports.gi.St;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
-const PopupMenu = imports.ui.popupMenu;
-const Slider = imports.ui.slider;
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext.domain('text-scaler');
-const _ = Gettext.gettext;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as Slider from 'resource:///org/gnome/shell/ui/slider.js';
+
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const DEFAULT_VALUE = 1.00;
 const MIN_VALUE = 0.50;
@@ -208,18 +205,17 @@ var TextScalerButton = GObject.registerClass({
 }
 );
 
-let _button = null;
+export default class LGButtonExtension extends Extension {
+    enable() {
+        this._button = new TextScalerButton();
+        Main.panel.addToStatusArea('text-scaler-button', this._button.actor);
+    }
 
-function init() {
-    ExtensionUtils.initTranslations("text-scaler");
+    disable() {
+        if (this._button !== null) {
+            this._button.actor.destroy();
+            this._button = null;
+        }
+    }
 }
 
-function enable() {
-    _button = new TextScalerButton();
-    Main.panel.addToStatusArea('text-scaler-button', _button.actor);
-}
-
-function disable() {
-    _button.actor.destroy();
-    _button = null;
-}

--- a/extension.js
+++ b/extension.js
@@ -39,7 +39,7 @@ function _isDefaultFloatValue(value) {
     return Math.abs(value - DEFAULT_VALUE) < (Math.pow(10, -NUM_DECIMALS) / 2);
 }
 
-var TextScalerButton = GObject.registerClass({
+const TextScalerButton = GObject.registerClass({
     GTypeName: 'TextScalerButton',
 }, class A extends GObject.Object {
     constructor() {
@@ -88,14 +88,14 @@ var TextScalerButton = GObject.registerClass({
         this._menu.addMenuItem(this._separatorItem);
 
         this._resetValueItem = new PopupMenu.PopupMenuItem(_("Reset to default value"));
-        this._resetValueItem.connect('activate', (menuItem, event) => this._onResetValueActivate());
+        this._resetValueItem.connect('activate', () => this._onResetValueActivate());
         this._menu.addMenuItem(this._resetValueItem);
 
         // Make sure we first update the UI with the current state.
         this._updateUI();
     }
 
-    _onSettingsChanged(settings, key) {
+    _onSettingsChanged() {
         this._updateValue(this._get_text_scaling_factor(), false);
     }
 
@@ -111,7 +111,7 @@ var TextScalerButton = GObject.registerClass({
         this._updateValueFromTextEntry(entry);
     }
 
-    _onSliderValueChanged(slider) {
+    _onSliderValueChanged() {
         this._sliderValue = this._slider.value;
         this._updateEntry(_sliderValueToTextScaling(this._sliderValue));
 
@@ -124,18 +124,18 @@ var TextScalerButton = GObject.registerClass({
             this._updateValue(_sliderValueToTextScaling(this._sliderValue));
     }
 
-    _onSliderDragBegan(slider) {
+    _onSliderDragBegan() {
         this._sliderIsDragging = true;
     }
 
-    _onSliderDragEnded(slider) {
+    _onSliderDragEnded() {
         // We don't update the scaling factor on 'value-changed'
         // when explicitly dragging, so we need to do it here too.
         this._updateValue(_sliderValueToTextScaling(this._sliderValue));
         this._sliderIsDragging = false;
     }
 
-    _onResetValueActivate(menuItem, event) {
+    _onResetValueActivate() {
         this._updateValue(DEFAULT_VALUE);
     }
 
@@ -167,7 +167,7 @@ var TextScalerButton = GObject.registerClass({
     }
 
     _updateValue(value, updateSettings=false) {
-        if (this._currentValue == value)
+        if (this._currentValue === value)
             return;
 
         // Need to keep the value between the valid limits.
@@ -189,7 +189,7 @@ var TextScalerButton = GObject.registerClass({
     }
 
     _updateEntry(value=null) {
-        let valueToDisplay = (value != null) ? value : this._currentValue;
+        let valueToDisplay = (value !== null) ? value : this._currentValue;
 
         // We only show NUM_DECIMALS decimals on the text entry widget.
         this._entry.set_text(valueToDisplay.toFixed(NUM_DECIMALS));

--- a/metadata.json.in
+++ b/metadata.json.in
@@ -5,5 +5,5 @@
     "url": "@URL@",
     "version": "@VERSION@",
     "gettext-domain": "@GETTEXT_DOMAIN@",
-    "shell-version": ["42", "43"]
+    "shell-version": ["45"]
 }


### PR DESCRIPTION
Since ESM files contain import and export keywords, extension modules won't be compatible with older GNOME Shell versions. The old shell versions must be removed and only use 45 in shell-version in metadata.json!

[Port Extensions to GNOME Shell 45](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#shell-version)